### PR TITLE
v0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megascops",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Megascops"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Megascops"
-version = "0.2.0"
+version = "0.2.1"
 description = "A cameratrap media detection tool"
 authors = ["Zhengyi Dong <zhengyi.dong@outlook.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Megascops",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.megascops.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/lib/components/ConfigPanel.svelte
+++ b/src/lib/components/ConfigPanel.svelte
@@ -148,7 +148,7 @@
 
             <div class="col-span-full flex justify-end items-center gap-2 mt-2">
                 <span class="text-xs text-muted-foreground">
-                    v{appVersion}
+                    v{appVersion.value}
                 </span>
             </div>
         </div>

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -1,6 +1,4 @@
-import { getVersion } from "@tauri-apps/api/app";
-
-export const appVersion = await getVersion();
+export const appVersion = $state({ value: "" });
 
 export const dialogConfig = $state({
     isOpen: false,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,9 +14,15 @@
         openSelectedFolder,
         saveConfig,
     } from "$lib/utils";
-    import { dialogConfig, detectStatus, config } from "$lib/store.svelte";
+    import {
+        dialogConfig,
+        detectStatus,
+        config,
+        appVersion,
+    } from "$lib/store.svelte";
     import { DetectPanel, ConfigPanel } from "$lib/components";
     import { startTour } from "$lib/tour";
+    import { getVersion } from "@tauri-apps/api/app";
 
     listen<boolean>("health-status", (event) => {
         let status = event.payload;
@@ -65,6 +71,7 @@
     });
 
     onMount(async () => {
+        appVersion.value = await getVersion();
         await loadConfig();
         checkHealth();
         if (config.firstRun) {


### PR DESCRIPTION
fix: 🐛 Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)